### PR TITLE
Fix source map generation for nested javascripts

### DIFF
--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/ClosureCompilerProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/ClosureCompilerProcessor.groovy
@@ -39,12 +39,14 @@ class ClosureCompilerProcessor {
 		options.trustedStrings = true
 
 		translateMinifyOptions(options,minifyOptions)
+
 		if(assetCompiler.options.enableSourceMaps) {
 			setSourceMapOptions(options,minifyOptions, fileName)
 		}
 
+        String baseFileName = new File(fileName).name
 		WarningLevel.QUIET.setOptionsForWarningLevel(options);
-		SourceFile sourceFile = SourceFile.fromCode(fileName + ".unminified.js", inputText)
+		SourceFile sourceFile = SourceFile.fromCode(baseFileName + ".unminified.js", inputText)
 		// def sourceFile = new SourceFile.Preloaded(fileName + ".unminified.js",fileName, inputText)
 		// sourceFile.setCode(inputText)
 		def result = compiler.compile([] as List<SourceFile>,[sourceFile] as List<SourceFile>,options)
@@ -59,10 +61,10 @@ class ClosureCompilerProcessor {
 			unminifiedFile.text = inputText
 			mapFile.createNewFile()
 			FileWriter outputWriter = new FileWriter(mapFile)
-			compiler.sourceMap.setWrapperPrefix("//# sourceMappingURL=${fileName + '.js.map'}\n")
-			compiler.sourceMap.appendTo(outputWriter,fileName + ".js")
+			compiler.sourceMap.setWrapperPrefix("//# sourceMappingURL=${baseFileName + '.js.map'}\n")
+			compiler.sourceMap.appendTo(outputWriter,baseFileName + ".js")
 			outputWriter.close();
-			output = "//# sourceMappingURL=${fileName + '.js.map'}\n" + output
+			output = "//# sourceMappingURL=${baseFileName + '.js.map'}\n" + output
 		}
 		return output
 	}


### PR DESCRIPTION
It looks like source maps resolve correctly for scripts in the top level of the assets directory, but the browser can't find the maps for nested JS files.  It looks like browsers (I tested in Chrome and FF) look for the source map relative to script so only the filename needs to be used when generating it.

For example if the entire path is passed to the generator for jquery/js/jquery-1.11.1.js the browswer will end up looking for jquery/js/jquery/js/jquery-1.11.1.js.map.

This change just trims the path from the file name to prevent this double path problem.

This pull request relates to https://github.com/bertramdev/asset-pipeline/pull/251 which is necessary to get source maps working at all.