### PR TITLE
Fix for issue #262: bug in HtmlProcessor#isRelativePath(assetPath)

### DIFF
--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/CssProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/CssProcessor.groovy
@@ -15,10 +15,12 @@
  */
 package asset.pipeline.processors
 
+
 import asset.pipeline.*
-import java.net.URL
-import java.net.URI
-import groovy.transform.CompileStatic
+
+import static asset.pipeline.utils.net.Urls.isRelative
+
+
 /**
 * This Processor iterates over relative image paths in a CSS file and
 * recalculates their path relative to the base file. In precompiler mode
@@ -37,12 +39,12 @@ class CssProcessor extends AbstractProcessor {
                 String replacementPath = assetPath.trim()
                 if(cachedPaths[assetPath]) {
                     replacementPath = cachedPaths[assetPath].path
-                } else if(replacementPath.size() > 0 && isRelativePath(replacementPath)) {
+                } else if(replacementPath.size() > 0 && isRelative(replacementPath)) {
                     def urlRep = new URL("http://hostname/${replacementPath}") //Split out subcomponents
                     def relativeFileName = assetFile.parentPath ? [assetFile.parentPath,urlRep.path.substring(1)].join("/") : urlRep.path.substring(1)
                     def normalizedFileName = AssetHelper.normalizePath(relativeFileName)
                     def cssFile = null
-        
+
                     if(!cssFile) {
                         cssFile = AssetHelper.fileForFullName(normalizedFileName)
                     }
@@ -61,10 +63,6 @@ class CssProcessor extends AbstractProcessor {
                 }
                 return "url('${replacementPath}')"
             }
-    }
-
-    private isRelativePath(assetPath) {
-        return !assetPath.startsWith("/") && !assetPath.startsWith("http")
     }
 
     private relativePathToBaseFile(file, baseFile, useDigest=false) {
@@ -114,5 +112,4 @@ class CssProcessor extends AbstractProcessor {
 
         return calculatedPath.join(AssetHelper.DIRECTIVE_FILE_SEPARATOR)
     }
-
 }

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/utils/net/Urls.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/utils/net/Urls.groovy
@@ -1,0 +1,34 @@
+package asset.pipeline.utils.net
+
+
+import java.util.regex.Pattern
+
+
+/**
+ * @author Ross Goldberg
+ */
+final class Urls {
+
+    /**
+     * URL starts with either {@code "/"} or a <a href="https://tools.ietf.org/html/std66">URI scheme</a> followed by {@code "/"}
+     */
+    static final Pattern ABSOLUTE_URL_PATTERN = ~/(?:\/|\p{L}[\p{L}\d+-.]*:[\/]).*/
+
+
+    /**
+     * URL starts with either {@code "/"} or a <a href="https://tools.ietf.org/html/std66">URI scheme</a> followed by {@code "/"}
+     */
+    static isAbsolute(final String url) {
+        ABSOLUTE_URL_PATTERN.matcher(url).matches()
+    }
+
+    /**
+     * URL does not start with either {@code "/"} or a <a href="https://tools.ietf.org/html/std66">URI scheme</a> followed by {@code "/"}
+     */
+    static isRelative(final String url) {
+        ! isAbsolute(url)
+    }
+
+
+    private Urls() {}
+}


### PR DESCRIPTION
@davydotcom

Here's the fix for issue #262: bug in HtmlProcessor#isRelativePath(assetPath)

Changes:

Factored out isRelativePath from CssProcessor & HtmlProcessor into Urls.isRelative

Changed logic from: path is relative if:

path doesn't start with "/" or "http"

to:

path doesn't start with "/" or a URI scheme (see https://en.wikipedia.org/wiki/URI_scheme#Generic_syntax) followed by "/"