### PR TITLE
Asset processor cleanup

### DIFF
--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/CssProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/CssProcessor.groovy
@@ -37,7 +37,7 @@ import static asset.pipeline.utils.net.Urls.isRelative
  */
 class CssProcessor extends AbstractProcessor {
 
-    private static final Pattern URL_CALL_PATTERN = ~/url\((?:\s*)['"]?([a-zA-Z0-9\-_.\/@#? &+%=]+)['"]?(?:\s*)\)/
+    private static final Pattern URL_CALL_PATTERN = ~/url\((?:\s*)(['"]?)([a-zA-Z0-9\-_.\/@#? &+%=]++)\1?(?:\s*)\)/
 
 
     CssProcessor(final AssetCompiler precompiler) {
@@ -50,11 +50,13 @@ class CssProcessor extends AbstractProcessor {
         return \
             inputText.replaceAll(URL_CALL_PATTERN) {
                 final String urlCall,
+                final String quote,
                 final String assetPath
             ->
-                final String cachedPath      = cachedPaths[assetPath]
+                final String cachedPath = cachedPaths[assetPath]
+
                 final String replacementPath
-                if (cachedPath) {
+                if (cachedPath != null) {
                     replacementPath = cachedPath
                 }
                 else if (assetPath.size() > 0 && isRelative(assetPath)) {
@@ -71,19 +73,19 @@ class CssProcessor extends AbstractProcessor {
                         if (url.ref) {
                             replacementPathSb.append('#').append(url.ref)
                         }
-                        replacementPath = replacementPathSb.toString()
+                        replacementPath        = replacementPathSb.toString()
+                        cachedPaths[assetPath] = replacementPath
                     }
                     else {
-                        replacementPath = assetPath
+                        cachedPaths[assetPath] = assetPath
+                        return urlCall
                     }
-
-                    cachedPaths[assetPath] = replacementPath
                 }
                 else {
-                    replacementPath = assetPath
+                    return urlCall
                 }
 
-                return "url('${replacementPath}')"
+                return "url(${quote}${replacementPath}${quote})"
             }
     }
 

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
@@ -16,108 +16,115 @@
 package asset.pipeline.processors
 
 
-import asset.pipeline.*
+import asset.pipeline.AbstractProcessor
+import asset.pipeline.AssetCompiler
+import asset.pipeline.AssetFile
+import asset.pipeline.AssetHelper
+import asset.pipeline.DirectiveProcessor
+import asset.pipeline.GenericAssetFile
+import java.util.regex.Pattern
 
 import static asset.pipeline.utils.net.Urls.isRelative
 
 
 /**
-* This Processor iterates over relative image paths in an HTML file and
-* recalculates their path relative to the base file. In precompiler mode
-* the image urls are also cache digested.
-* @author David Estes
-*/
+ * This Processor iterates over relative image paths in an HTML file and
+ * recalculates their path relative to the base file. In precompiler mode
+ * the image URLs are also cache digested.
+ *
+ * @author David Estes
+ * @author Ross Goldberg
+ */
 class HtmlProcessor extends AbstractProcessor {
 
-    HtmlProcessor(AssetCompiler precompiler) {
+    private static final Pattern QUOTED_ASSET_PATH_PATTERN = ~/"([a-zA-Z0-9\-_.\/@#? &+%=']+)"|'([a-zA-Z0-9\-_.\/@#? &+%="]+)'/
+
+
+    HtmlProcessor(final AssetCompiler precompiler) {
         super(precompiler)
     }
 
-    String process(String inputText, AssetFile assetFile) {
-            Map cachedPaths = [:]
-            return inputText.replaceAll(/[\"]([a-zA-Z0-9\-\_\.\/\@\#\?\ \&\+\%\=\']+)[\"]|[\']([a-zA-Z0-9\-\_\.\/\@\#\?\ \&\+\%\=\"]+)[\']/) { fullMatch, assetDoublePath, assetSinglePath ->
-                def assetPath = assetDoublePath ?: assetSinglePath
-                def encapsulationString = assetDoublePath ? '"' : '\''
-                String replacementPath = assetPath.trim()
-                if(cachedPaths[assetPath]) {
-                    replacementPath = cachedPaths[assetPath].path
-                } else if(replacementPath.size() > 0 && isRelative(replacementPath)) {
-                    def urlRep = new URL("http://hostname/${replacementPath}") //Split out subcomponents
-                    def relativeFileName = assetFile.parentPath ? [assetFile.parentPath,urlRep.path.substring(1)].join("/") : urlRep.path.substring(1)
-                    def normalizedFileName = AssetHelper.normalizePath(relativeFileName)
-                    def cssFile = null
 
-                    if(!cssFile) {
-                        cssFile = AssetHelper.fileForFullName(normalizedFileName)
-                    }
-                    if(cssFile) {
-                        replacementPath = relativePathToBaseFile(cssFile, assetFile.baseFile ?: assetFile, this.precompiler && this.precompiler.options.enableDigests ? true : false)
-                        if(urlRep.query != null) {
-                            replacementPath += "?${urlRep.query}"
-                        }
-                        if(urlRep.ref) {
-                            replacementPath += "#${urlRep.ref}"
-                        }
-                        cachedPaths[assetPath] = [path:replacementPath]
-                    } else {
-                        cachedPaths[assetPath] = [path: replacementPath]
-                    }
+    String process(final String inputText, final AssetFile assetFile) {
+        final Map<String, String> cachedPaths = [:]
+        return \
+            inputText.replaceAll(QUOTED_ASSET_PATH_PATTERN) {
+                final String quotedAssetPath,
+                final String doubleQuotedAssetPath,
+                final String singleQuotedAssetPath
+            ->
+                final String assetPath       = (doubleQuotedAssetPath ?: singleQuotedAssetPath).trim()
+                final String cachedPath      = cachedPaths[assetPath]
+                final String replacementPath
+                if (cachedPath) {
+                    replacementPath = cachedPath
                 }
-                return "${encapsulationString}${replacementPath}${encapsulationString}"
+                else if (assetPath.size() > 0 && isRelative(assetPath)) {
+                    final URL       url              = new URL("http://hostname/${assetPath}") // Split out subcomponents
+                    final String    relativeFileName = assetFile.parentPath ? assetFile.parentPath + url.path : url.path.substring(1)
+                    final AssetFile file             = AssetHelper.fileForFullName(AssetHelper.normalizePath(relativeFileName))
+
+                    if (file) {
+                        final StringBuilder replacementPathSb = new StringBuilder()
+                        replacementPathSb.append(relativePathToBaseFile(file, assetFile.baseFile ?: assetFile, precompiler && precompiler.options.enableDigests))
+                        if (url.query != null) {
+                            replacementPathSb.append('?').append(url.query)
+                        }
+                        if (url.ref) {
+                            replacementPathSb.append('#').append(url.ref)
+                        }
+                        replacementPath = replacementPathSb.toString()
+                    }
+                    else {
+                        replacementPath = assetPath
+                    }
+
+                    cachedPaths[assetPath] = replacementPath
+                }
+                else {
+                    replacementPath = assetPath
+                }
+
+                final String quote = doubleQuotedAssetPath ? '"' : /'/
+                return "${quote}${replacementPath}${quote}"
             }
     }
 
-    private relativePathToBaseFile(file, baseFile, useDigest=false) {
-        def baseRelativePath = baseFile.parentPath ? baseFile.parentPath.split(AssetHelper.DIRECTIVE_FILE_SEPARATOR).findAll{it}.reverse() : []
-        def currentRelativePath = file.parentPath ? file.parentPath.split(AssetHelper.DIRECTIVE_FILE_SEPARATOR).findAll({it}).reverse() : []
-        def filePathIndex=currentRelativePath.size()- 1
-        def baseFileIndex=baseRelativePath.size() - 1
+    private String relativePathToBaseFile(final AssetFile file, final AssetFile baseFile, final boolean useDigest = false) {
+        final List<String> baseRelativePath = baseFile.parentPath ? baseFile.parentPath.split(AssetHelper.DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
+        final List<String> currRelativePath =     file.parentPath ?     file.parentPath.split(AssetHelper.DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
 
-        while(filePathIndex > 0 && baseFileIndex > 0 && baseRelativePath[baseFileIndex] == currentRelativePath[filePathIndex]) {
+        int filePathIndex = currRelativePath.size() - 1
+        int baseFileIndex = baseRelativePath.size() - 1
+
+        while (filePathIndex > 0 && baseFileIndex > 0 && baseRelativePath[baseFileIndex] == currRelativePath[filePathIndex]) {
             filePathIndex--
             baseFileIndex--
         }
 
-        def calculatedPath = []
+        final List<String> calculatedPath = new ArrayList<>(baseFileIndex + filePathIndex + 3)
 
         // for each remaining level in the home path, add a ..
-        for(;baseFileIndex>=0;baseFileIndex--) {
-            calculatedPath << ".."
+        for (; baseFileIndex >= 0; baseFileIndex--) {
+            calculatedPath << '..'
         }
 
-        for(;filePathIndex>=0;filePathIndex--) {
-            calculatedPath << currentRelativePath[filePathIndex]
+        for (; filePathIndex >= 0; filePathIndex--) {
+            calculatedPath << currRelativePath[filePathIndex]
         }
-        if(useDigest) {
-            def extension = AssetHelper.extensionFromURI(file.getName())
-            def fileName  = AssetHelper.nameWithoutExtension(file.getName())
-            def digestName
-            if(!(file instanceof GenericAssetFile)) {
-                if(file.compiledExtension != 'html') {
-                    extension = file.compiledExtension
-                    def directiveProcessor = new DirectiveProcessor(baseFile.contentType[0], precompiler)
-                    def fileData   = directiveProcessor.compile(file)
-                    digestName = AssetHelper.getByteDigest(fileData.bytes)
-                    calculatedPath << "${fileName}-${digestName}.${extension}"
-                } else {
-                    extension = file.compiledExtension
-                    calculatedPath << "${fileName}.${extension}"
-                }
-            }
-            else {
-                digestName = AssetHelper.getByteDigest(file.bytes)
-                calculatedPath << "${fileName}-${digestName}.${extension}"
-            }
 
-        } else {
-            if(!(file instanceof GenericAssetFile)) {
-                def fileName  = AssetHelper.nameWithoutExtension(file.getName())
-                def extension = file.compiledExtension
-                calculatedPath << "${fileName}.${extension}"
-            } else {
-                calculatedPath << file.getName()
-            }
-        }
+        final String fileName = AssetHelper.nameWithoutExtension(file.name)
+        calculatedPath << (
+            useDigest
+                ? file instanceof GenericAssetFile
+                    ? "${fileName}-${AssetHelper.getByteDigest(file.bytes)}.${AssetHelper.extensionFromURI(file.name)}"
+                    : file.compiledExtension != 'html' \
+                        ? "${fileName}-${AssetHelper.getByteDigest(new DirectiveProcessor(baseFile.contentType[0], precompiler).compile(file).bytes)}.${file.compiledExtension}"
+                        : "${fileName}.${file.compiledExtension}"
+                : file instanceof GenericAssetFile
+                    ? file.name
+                    : fileName + '.' + file.compiledExtension
+        )
 
         return calculatedPath.join(AssetHelper.DIRECTIVE_FILE_SEPARATOR)
     }


### PR DESCRIPTION
@davydotcom 

I cleaned up the asset processors (`CssProcessor` & `HtmlProcessor`)

The changes visible to users:

* `HtmlProcessor`: fixed bug where spaces between attributes were removed
* `CssProcessor`: preserve the quote character from source CSS (`'`, `"`, or nothing)
* `CssProcessor`: ensure path string quotes are same at start & end

I added variable types, as we discussed, and I cleaned up the code otherwise.

My attempted performance improvements didn't really make a difference, but the code is cleaner nonetheless.

One potential existing performance issue that I didn't try to fix:

`AssetHelper#getByteDigest(byte[])` is called with an argument obtained from `AssetFile#getBytes()`.  The latter returns `Byte[]`, so I assume that Grails must always convert from `Byte[]` to `byte[]`.

Maybe making both use either `Byte[]` or `byte[]` might improve performance.  I would imagine that `byte[]` is preferable, but I didn't investigate the rest of the code to see which array element type would be best in AP.