### PR TITLE
Fixing project so Gradle can run without bintray properties

### DIFF
--- a/asset-pipeline-spring-boot/build.gradle
+++ b/asset-pipeline-spring-boot/build.gradle
@@ -21,21 +21,11 @@ group = 'com.bertramlabs.plugins'
 
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
-if(!project.hasProperty('bintrayUser')) {
-	bintrayUser = 'test'
-}
-if(!project.hasProperty('bintrayKey')) {
-	bintrayKey = 'empty'
-}
-
-
-
 repositories {
 	jcenter()
 	mavenLocal()
 	mavenCentral()
 }
-
 
 dependencies {
 	compile gradleApi()
@@ -95,8 +85,8 @@ publishing {
 }
 
 bintray {
-	user = bintrayUser
-	key = bintrayKey
+	user = project.hasProperty('bintrayUsername') ? project.bintrayUsername : 'test'
+        key = project.hasProperty('bintrayApiKey') ? project.bintrayApiKey : 'empty'
 	publications = ['maven']
 	pkg {
 		repo = 'asset-pipeline'

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ subprojects {
 	version = '2.3.6'
 }
 
-
 apply plugin: 'groovy'
 
 group = 'com.bertramlabs.plugins'
@@ -31,11 +30,13 @@ dependencies {
 	testCompile("org.spockframework:spock-core:0.7-groovy-2.0")
 }
 
-
-
 test {
 	testLogging {
 		exceptionFormat = 'full'
 		showStandardStreams = true
 	}
+}
+
+task wrapper(type: Wrapper) {
+	gradleVersion = '2.4'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 01 07:42:33 CST 2014
+#Thu Jun 25 20:27:45 EDT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-bin.zip


### PR DESCRIPTION
This fixes the spring boot project so I can run gradle. Also added the wrapper for 2.4.