### PR TITLE
Only write to manifest.properties when digests enabled

### DIFF
--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/AssetCompiler.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/AssetCompiler.groovy
@@ -202,8 +202,8 @@ class AssetCompiler {
 								digestedFile = new File(options.compileDir,"${fileSystemName}-${digestName}${extension ? ('.' + extension) : ''}")
 								digestedFile.createNewFile()
 								digestedFile.bytes = outputBytes
+								manifestProperties.setProperty("${fileName}.${extension}", "${fileName}-${digestName}${extension ? ('.' + extension) : ''}")
 							}
-							manifestProperties.setProperty("${fileName}.${extension}", "${fileName}-${digestName}${extension ? ('.' + extension) : ''}")
 
 							// Zip it Good!
 							if(options.enableGzip == true && !options.excludesGzip.find{ it.toLowerCase() == extension.toLowerCase()}) {


### PR DESCRIPTION
This is necessary for [pull request #273 for asset-pipeline](https://github.com/bertramdev/asset-pipeline/pull/273) for [issue #272 for asset-pipeline](https://github.com/bertramdev/asset-pipeline/issues/272).

I branched this from `master` instead of the `rel-2.3.8` tag.  So my branch should either be merged into `tags/rel-2.3.8`, or they both should be merged into `master`.