### PR TITLE
Compare last parent path component for url rewriting

### DIFF
--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/CssProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/CssProcessor.groovy
@@ -89,7 +89,7 @@ class CssProcessor extends AbstractProcessor {
         int filePathIndex = currRelativePath.size() - 1
         int baseFileIndex = baseRelativePath.size() - 1
 
-        while (filePathIndex > 0 && baseFileIndex > 0 && baseRelativePath[baseFileIndex] == currRelativePath[filePathIndex]) {
+        while (filePathIndex >= 0 && baseFileIndex >= 0 && baseRelativePath[baseFileIndex] == currRelativePath[filePathIndex]) {
             filePathIndex--
             baseFileIndex--
         }

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
@@ -100,7 +100,7 @@ class HtmlProcessor extends AbstractProcessor {
         int filePathIndex = currRelativePath.size() - 1
         int baseFileIndex = baseRelativePath.size() - 1
 
-        while (filePathIndex > 0 && baseFileIndex > 0 && baseRelativePath[baseFileIndex] == currRelativePath[filePathIndex]) {
+        while (filePathIndex >= 0 && baseFileIndex >= 0 && baseRelativePath[baseFileIndex] == currRelativePath[filePathIndex]) {
             filePathIndex--
             baseFileIndex--
         }


### PR DESCRIPTION
Pull request for issue #27.

Before this commit, e.g., in an asset file located at `a/b/c/1.html`, the relative URL `d/2.html` would be rewritten as `../c/d/2.html` (ignoring cache digests).

After this commit, the URL will remain as `d/2.html`.

Maybe there is a reason for the old behavior that I've missed, so maybe this shouldn't be merged into master...

This was branched from tag `rel-2.3.8`, so it will merge the one commit in that tag into `master`.