### PR TITLE
URL-rewriting processors cleanup

### DIFF
--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
@@ -4,8 +4,12 @@ package asset.pipeline.processors
 import asset.pipeline.AbstractProcessor
 import asset.pipeline.AssetCompiler
 import asset.pipeline.AssetFile
-import asset.pipeline.AssetHelper
 import asset.pipeline.GenericAssetFile
+
+import static asset.pipeline.AssetHelper.DIRECTIVE_FILE_SEPARATOR
+import static asset.pipeline.AssetHelper.extensionFromURI
+import static asset.pipeline.AssetHelper.getByteDigest
+import static asset.pipeline.AssetHelper.nameWithoutExtension
 
 
 /**
@@ -24,8 +28,8 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
 
 
     protected String relativePathFromBaseFile(final AssetFile file, final AssetFile baseFile, final boolean useDigest = false) {
-        final List<String> baseRelativePath = baseFile.parentPath ? baseFile.parentPath.split(AssetHelper.DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
-        final List<String> currRelativePath =     file.parentPath ?     file.parentPath.split(AssetHelper.DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
+        final List<String> baseRelativePath = baseFile.parentPath ? baseFile.parentPath.split(DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
+        final List<String> currRelativePath =     file.parentPath ?     file.parentPath.split(DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
 
         int filePathIndex = currRelativePath.size() - 1
         int baseFileIndex = baseRelativePath.size() - 1
@@ -46,18 +50,18 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
             calculatedPath << currRelativePath[filePathIndex]
         }
 
-        final String fileName = AssetHelper.nameWithoutExtension(file.name)
+        final String fileName = nameWithoutExtension(file.name)
         calculatedPath << (
             useDigest
                 ? file instanceof GenericAssetFile
-                    ? "${fileName}-${AssetHelper.getByteDigest(file.bytes)}.${AssetHelper.extensionFromURI(file.name)}"
-                    : digestedNonGenericAssetFileName()
+                    ? "${fileName}-${getByteDigest(file.bytes)}.${extensionFromURI(file.name)}"
+                    : digestedNonGenericAssetFileName(file, baseFile, fileName)
                 : file instanceof GenericAssetFile
                     ? file.name
                     : fileName + '.' + file.compiledExtension
         )
 
-        return calculatedPath.join(AssetHelper.DIRECTIVE_FILE_SEPARATOR)
+        return calculatedPath.join(DIRECTIVE_FILE_SEPARATOR)
     }
 
 

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
@@ -61,7 +61,7 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
         }
 
         // relative parent path
-        final String baseFileParentPath = assetFile.baseFile?.parentPath ?: assetFile.parentPath
+        final String baseFileParentPath = (assetFile.baseFile ?: assetFile).parentPath
         final String currFileParentPath = currFile.parentPath
 
         final List<String> baseRelativePath = baseFileParentPath ? baseFileParentPath.split('/').findAll {it}.reverse() : []

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
@@ -30,15 +30,15 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
     }
 
 
-    protected String replacementUrl(final AssetFile assetFile, final String path) {
-        final URL url = new URL("http://hostname/${path}") // used to split path subcomponents
+    protected String replacementUrl(final AssetFile assetFile, final String url) {
+        final URL urlSplitter = new URL("http://hostname/${url}")
 
         final AssetFile currFile =
             fileForFullName(
                 normalizePath(
                     assetFile.parentPath
-                        ? assetFile.parentPath + url.path
-                        : url.path.substring(1)
+                        ? assetFile.parentPath + urlSplitter.path
+                        : urlSplitter.path.substring(1)
                 )
             )
 
@@ -82,12 +82,12 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
                     : fileName + '.' + currFile.compiledExtension
         )
 
-        if (url.query != null) {
-            replacementPathSb.append('?').append(url.query)
+        if (urlSplitter.query != null) {
+            replacementPathSb.append('?').append(urlSplitter.query)
         }
 
-        if (url.ref) {
-            replacementPathSb.append('#').append(url.ref)
+        if (urlSplitter.ref) {
+            replacementPathSb.append('#').append(urlSplitter.ref)
         }
 
         return replacementPathSb.toString()

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
@@ -8,12 +8,15 @@ import asset.pipeline.GenericAssetFile
 
 import static asset.pipeline.AssetHelper.DIRECTIVE_FILE_SEPARATOR
 import static asset.pipeline.AssetHelper.extensionFromURI
+import static asset.pipeline.AssetHelper.fileForFullName
 import static asset.pipeline.AssetHelper.getByteDigest
 import static asset.pipeline.AssetHelper.nameWithoutExtension
+import static asset.pipeline.AssetHelper.normalizePath
 
 
 /**
  * @author Ross Goldberg
+ * @author David Estes
  */
 abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
 
@@ -27,41 +30,65 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
     }
 
 
-    protected String relativePathFromBaseFile(final AssetFile file, final AssetFile baseFile, final boolean useDigest = false) {
-        final List<String> baseRelativePath = baseFile.parentPath ? baseFile.parentPath.split(DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
-        final List<String> currRelativePath =     file.parentPath ?     file.parentPath.split(DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
+    protected String replacementUrl(final AssetFile assetFile, final String path) {
+        final URL       url      = new URL("http://hostname/${path}") // used to split path subcomponents
+        final AssetFile currFile =
+            fileForFullName(
+                normalizePath(
+                    assetFile.parentPath
+                        ? assetFile.parentPath + url.path
+                        : url.path.substring(1)
+                )
+            )
 
-        int filePathIndex = currRelativePath.size() - 1
-        int baseFileIndex = baseRelativePath.size() - 1
-
-        while (filePathIndex > 0 && baseFileIndex > 0 && baseRelativePath[baseFileIndex] == currRelativePath[filePathIndex]) {
-            filePathIndex--
-            baseFileIndex--
+        if (! currFile) {
+            return null
         }
 
-        final List<String> calculatedPath = new ArrayList<>(baseFileIndex + filePathIndex + 3)
+        final AssetFile     baseFile          = assetFile.baseFile ?: assetFile
+        final boolean       useDigest         = precompiler && precompiler.options.enableDigests
+        final StringBuilder replacementPathSb = new StringBuilder()
+        final List<String>  baseRelativePath  = baseFile.parentPath ? baseFile.parentPath.split(DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
+        final List<String>  currRelativePath  = currFile.parentPath ? currFile.parentPath.split(DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
+
+        int baseIndex = baseRelativePath.size() - 1
+        int currIndex = currRelativePath.size() - 1
+
+        while (baseIndex > 0 && currIndex > 0 && baseRelativePath[baseIndex] == currRelativePath[currIndex]) {
+            baseIndex--
+            currIndex--
+        }
 
         // for each remaining level in the base path, add a ..
-        for (; baseFileIndex >= 0; baseFileIndex--) {
-            calculatedPath << '..'
+        for (; baseIndex >= 0; baseIndex--) {
+            replacementPathSb.append('../')
         }
 
-        for (; filePathIndex >= 0; filePathIndex--) {
-            calculatedPath << currRelativePath[filePathIndex]
+        for (; currIndex >= 0; currIndex--) {
+            replacementPathSb.append(currRelativePath[currIndex])
+            replacementPathSb.append('/' as char)
         }
 
-        final String fileName = nameWithoutExtension(file.name)
-        calculatedPath << (
+        final String fileName = nameWithoutExtension(currFile.name)
+        replacementPathSb.append(
             useDigest
-                ? file instanceof GenericAssetFile
-                    ? "${fileName}-${getByteDigest(file.bytes)}.${extensionFromURI(file.name)}"
-                    : digestedNonGenericAssetFileName(file, baseFile, fileName)
-                : file instanceof GenericAssetFile
-                    ? file.name
-                    : fileName + '.' + file.compiledExtension
+                ? currFile instanceof GenericAssetFile
+                    ? "${fileName}-${getByteDigest(currFile.bytes)}.${extensionFromURI(currFile.name)}"
+                    : digestedNonGenericAssetFileName(currFile, baseFile, fileName)
+                : currFile instanceof GenericAssetFile
+                    ? currFile.name
+                    : fileName + '.' + currFile.compiledExtension
         )
 
-        return calculatedPath.join(DIRECTIVE_FILE_SEPARATOR)
+        if (url.query != null) {
+            replacementPathSb.append('?').append(url.query)
+        }
+
+        if (url.ref) {
+            replacementPathSb.append('#').append(url.ref)
+        }
+
+        return replacementPathSb.toString()
     }
 
 

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
@@ -1,0 +1,65 @@
+package asset.pipeline.processors
+
+
+import asset.pipeline.AbstractProcessor
+import asset.pipeline.AssetCompiler
+import asset.pipeline.AssetFile
+import asset.pipeline.AssetHelper
+import asset.pipeline.GenericAssetFile
+
+
+/**
+ * @author Ross Goldberg
+ */
+abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
+
+    /**
+     * Constructor for building a Processor
+     *
+     * @param precompiler - An Instance of the AssetCompiler class compiling the file or NULL for dev mode.
+     */
+    AbstractUrlRewritingProcessor(final AssetCompiler precompiler) {
+        super(precompiler)
+    }
+
+
+    protected String relativePathFromBaseFile(final AssetFile file, final AssetFile baseFile, final boolean useDigest = false) {
+        final List<String> baseRelativePath = baseFile.parentPath ? baseFile.parentPath.split(AssetHelper.DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
+        final List<String> currRelativePath =     file.parentPath ?     file.parentPath.split(AssetHelper.DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
+
+        int filePathIndex = currRelativePath.size() - 1
+        int baseFileIndex = baseRelativePath.size() - 1
+
+        while (filePathIndex > 0 && baseFileIndex > 0 && baseRelativePath[baseFileIndex] == currRelativePath[filePathIndex]) {
+            filePathIndex--
+            baseFileIndex--
+        }
+
+        final List<String> calculatedPath = new ArrayList<>(baseFileIndex + filePathIndex + 3)
+
+        // for each remaining level in the base path, add a ..
+        for (; baseFileIndex >= 0; baseFileIndex--) {
+            calculatedPath << '..'
+        }
+
+        for (; filePathIndex >= 0; filePathIndex--) {
+            calculatedPath << currRelativePath[filePathIndex]
+        }
+
+        final String fileName = AssetHelper.nameWithoutExtension(file.name)
+        calculatedPath << (
+            useDigest
+                ? file instanceof GenericAssetFile
+                    ? "${fileName}-${AssetHelper.getByteDigest(file.bytes)}.${AssetHelper.extensionFromURI(file.name)}"
+                    : digestedNonGenericAssetFileName()
+                : file instanceof GenericAssetFile
+                    ? file.name
+                    : fileName + '.' + file.compiledExtension
+        )
+
+        return calculatedPath.join(AssetHelper.DIRECTIVE_FILE_SEPARATOR)
+    }
+
+
+    protected abstract String digestedNonGenericAssetFileName(AssetFile file, AssetFile baseFile, String fileName)
+}

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
@@ -31,7 +31,8 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
 
 
     protected String replacementUrl(final AssetFile assetFile, final String path) {
-        final URL       url      = new URL("http://hostname/${path}") // used to split path subcomponents
+        final URL url = new URL("http://hostname/${path}") // used to split path subcomponents
+
         final AssetFile currFile =
             fileForFullName(
                 normalizePath(
@@ -45,11 +46,10 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
             return null
         }
 
-        final AssetFile     baseFile          = assetFile.baseFile ?: assetFile
-        final boolean       useDigest         = precompiler && precompiler.options.enableDigests
-        final StringBuilder replacementPathSb = new StringBuilder()
-        final List<String>  baseRelativePath  = baseFile.parentPath ? baseFile.parentPath.split(DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
-        final List<String>  currRelativePath  = currFile.parentPath ? currFile.parentPath.split(DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
+        final AssetFile baseFile = assetFile.baseFile ?: assetFile
+
+        final List<String> baseRelativePath = baseFile.parentPath ? baseFile.parentPath.split(DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
+        final List<String> currRelativePath = currFile.parentPath ? currFile.parentPath.split(DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
 
         int baseIndex = baseRelativePath.size() - 1
         int currIndex = currRelativePath.size() - 1
@@ -58,6 +58,8 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
             baseIndex--
             currIndex--
         }
+
+        final StringBuilder replacementPathSb = new StringBuilder()
 
         // for each remaining level in the base path, add a ..
         for (; baseIndex >= 0; baseIndex--) {
@@ -71,7 +73,7 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
 
         final String fileName = nameWithoutExtension(currFile.name)
         replacementPathSb.append(
-            useDigest
+            precompiler?.options.enableDigests
                 ? currFile instanceof GenericAssetFile
                     ? "${fileName}-${getByteDigest(currFile.bytes)}.${extensionFromURI(currFile.name)}"
                     : digestedNonGenericAssetFileName(currFile, baseFile, fileName)

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
@@ -85,12 +85,7 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
 
         // file
         final Map     options       = precompiler?.options
-        final boolean enableDigests =
-            options \
-                ? options.containsKey('enableDigests') \
-                    ? options.enableDigests
-                    : true
-                : true
+        final boolean enableDigests = ! options?.containsKey('enableDigests') || options.enableDigests
 
         replacementPathSb << (
             enableDigests \

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/CssProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/CssProcessor.groovy
@@ -76,7 +76,7 @@ class CssProcessor extends AbstractUrlRewritingProcessor {
     }
 
     @Override
-    protected String digestedNonGenericAssetFileName(final AssetFile file, final AssetFile baseFile, final String fileName) {
-        return "${fileName}-${getByteDigest(new DirectiveProcessor(baseFile.contentType[0], precompiler).compile(file).bytes)}.${file.compiledExtension}"
+    protected String digestedNonGenericAssetFileName(final AssetFile assetFile, final String fileNameSansExt) {
+        return "${fileNameSansExt}-${getByteDigest(new DirectiveProcessor(null, precompiler).compile(assetFile).bytes)}.${assetFile.compiledExtension}"
     }
 }

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/CssProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/CssProcessor.groovy
@@ -35,7 +35,7 @@ import static asset.pipeline.utils.net.Urls.isRelative
  */
 class CssProcessor extends AbstractUrlRewritingProcessor {
 
-    private static final Pattern URL_CALL_PATTERN = ~/url\((?:\s*)(['"]?)([a-zA-Z0-9\-_.\/@#? &+%=]++)\1?(?:\s*)\)/
+    private static final Pattern URL_CALL_PATTERN = ~/url\((?:\s*)(['"]?)([a-zA-Z0-9\-_.:\/@#? &+%=]++)\1?(?:\s*)\)/
 
 
     CssProcessor(final AssetCompiler precompiler) {

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/CssProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/CssProcessor.groovy
@@ -16,14 +16,14 @@
 package asset.pipeline.processors
 
 
-import asset.pipeline.AbstractProcessor
 import asset.pipeline.AssetCompiler
 import asset.pipeline.AssetFile
-import asset.pipeline.AssetHelper
 import asset.pipeline.DirectiveProcessor
-import asset.pipeline.GenericAssetFile
 import java.util.regex.Pattern
 
+import static asset.pipeline.AssetHelper.fileForFullName
+import static asset.pipeline.AssetHelper.getByteDigest
+import static asset.pipeline.AssetHelper.normalizePath
 import static asset.pipeline.utils.net.Urls.isRelative
 
 
@@ -35,7 +35,7 @@ import static asset.pipeline.utils.net.Urls.isRelative
  * @author David Estes
  * @author Ross Goldberg
  */
-class CssProcessor extends AbstractProcessor {
+class CssProcessor extends AbstractUrlRewritingProcessor {
 
     private static final Pattern URL_CALL_PATTERN = ~/url\((?:\s*)(['"]?)([a-zA-Z0-9\-_.\/@#? &+%=]++)\1?(?:\s*)\)/
 
@@ -48,20 +48,20 @@ class CssProcessor extends AbstractProcessor {
     String process(final String inputText, final AssetFile assetFile) {
         final Map<String, String> cachedPaths = [:]
         return \
-            inputText.replaceAll(URL_CALL_PATTERN) { final String urlCall, final String quote, final String assetPath ->
+            inputText.replaceAll(URL_CALL_PATTERN) {final String urlCall, final String quote, final String assetPath ->
                 final String cachedPath = cachedPaths[assetPath]
 
                 final String replacementPath
                 if (cachedPath != null) {
                     replacementPath = cachedPath
-                } else if (assetPath.size() > 0 && isRelative(assetPath)) {
+                } else if (assetPath.length() > 0 && isRelative(assetPath)) {
                     final URL       url              = new URL("http://hostname/${assetPath}") // Split out subcomponents
                     final String    relativeFileName = assetFile.parentPath ? assetFile.parentPath + url.path : url.path.substring(1)
-                    final AssetFile file             = AssetHelper.fileForFullName(AssetHelper.normalizePath(relativeFileName))
+                    final AssetFile file             = fileForFullName(normalizePath(relativeFileName))
 
                     if (file) {
                         final StringBuilder replacementPathSb = new StringBuilder()
-                        replacementPathSb.append(relativePathToBaseFile(file, assetFile.baseFile ?: assetFile, precompiler && precompiler.options.enableDigests))
+                        replacementPathSb.append(relativePathFromBaseFile(file, assetFile.baseFile ?: assetFile, precompiler && precompiler.options.enableDigests))
                         if (url.query != null) {
                             replacementPathSb.append('?').append(url.query)
                         }
@@ -82,40 +82,8 @@ class CssProcessor extends AbstractProcessor {
             }
     }
 
-    private String relativePathToBaseFile(final AssetFile file, final AssetFile baseFile, final boolean useDigest = false) {
-        final List<String> baseRelativePath = baseFile.parentPath ? baseFile.parentPath.split(AssetHelper.DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
-        final List<String> currRelativePath =     file.parentPath ?     file.parentPath.split(AssetHelper.DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
-
-        int filePathIndex = currRelativePath.size() - 1
-        int baseFileIndex = baseRelativePath.size() - 1
-
-        while (filePathIndex > 0 && baseFileIndex > 0 && baseRelativePath[baseFileIndex] == currRelativePath[filePathIndex]) {
-            filePathIndex--
-            baseFileIndex--
-        }
-
-        final List<String> calculatedPath = new ArrayList<>(baseFileIndex + filePathIndex + 3)
-
-        // for each remaining level in the home path, add a ..
-        for (; baseFileIndex >= 0; baseFileIndex--) {
-            calculatedPath << '..'
-        }
-
-        for (; filePathIndex >= 0; filePathIndex--) {
-            calculatedPath << currRelativePath[filePathIndex]
-        }
-
-        final String fileName = AssetHelper.nameWithoutExtension(file.name)
-        calculatedPath << (
-            useDigest
-                ? file instanceof GenericAssetFile
-                    ? "${fileName}-${AssetHelper.getByteDigest(file.bytes)}.${AssetHelper.extensionFromURI(file.name)}"
-                    : "${fileName}-${AssetHelper.getByteDigest(new DirectiveProcessor(baseFile.contentType[0], precompiler).compile(file).bytes)}.${file.compiledExtension}"
-                : file instanceof GenericAssetFile
-                    ? file.name
-                    : fileName + '.' + file.compiledExtension
-        )
-
-        return calculatedPath.join(AssetHelper.DIRECTIVE_FILE_SEPARATOR)
+    @Override
+    protected String digestedNonGenericAssetFileName(final AssetFile file, final AssetFile baseFile, final String fileName) {
+        return "${fileName}-${getByteDigest(new DirectiveProcessor(baseFile.contentType[0], precompiler).compile(file).bytes)}.${file.compiledExtension}"
     }
 }

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
@@ -35,7 +35,7 @@ import static asset.pipeline.utils.net.Urls.isRelative
  */
 class HtmlProcessor extends AbstractUrlRewritingProcessor {
 
-    private static final Pattern QUOTED_ASSET_PATH_PATTERN = ~/"([a-zA-Z0-9\-_.\/@#? &+%=']++)"|'([a-zA-Z0-9\-_.\/@#? &+%="]++)'/
+    private static final Pattern QUOTED_ASSET_PATH_PATTERN = ~/"([a-zA-Z0-9\-_.:\/@#? &+%=']++)"|'([a-zA-Z0-9\-_.:\/@#? &+%="]++)'/
 
 
     HtmlProcessor(final AssetCompiler precompiler) {

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
@@ -21,9 +21,7 @@ import asset.pipeline.AssetFile
 import asset.pipeline.DirectiveProcessor
 import java.util.regex.Pattern
 
-import static asset.pipeline.AssetHelper.fileForFullName
 import static asset.pipeline.AssetHelper.getByteDigest
-import static asset.pipeline.AssetHelper.normalizePath
 import static asset.pipeline.utils.net.Urls.isRelative
 
 
@@ -62,20 +60,8 @@ class HtmlProcessor extends AbstractUrlRewritingProcessor {
                     replacementPath = cachedPaths[trimmedPath] ?: assetPath
                 }
                 else if (trimmedPath.length() > 0 && isRelative(trimmedPath)) {
-                    final URL       url              = new URL("http://hostname/${trimmedPath}") // Split out subcomponents
-                    final String    relativeFileName = assetFile.parentPath ? assetFile.parentPath + url.path : url.path.substring(1)
-                    final AssetFile file             = fileForFullName(normalizePath(relativeFileName))
-
-                    if (file) {
-                        final StringBuilder replacementPathSb = new StringBuilder()
-                        replacementPathSb.append(relativePathFromBaseFile(file, assetFile.baseFile ?: assetFile, precompiler && precompiler.options.enableDigests))
-                        if (url.query != null) {
-                            replacementPathSb.append('?').append(url.query)
-                        }
-                        if (url.ref) {
-                            replacementPathSb.append('#').append(url.ref)
-                        }
-                        replacementPath          = replacementPathSb.toString()
+                    replacementPath  = replacementUrl(assetFile, trimmedPath)
+                    if (replacementPath) {
                         cachedPaths[trimmedPath] = replacementPath
                     }
                     else {
@@ -88,7 +74,7 @@ class HtmlProcessor extends AbstractUrlRewritingProcessor {
                     return quotedAssetPathWithQuotes
                 }
 
-                final String quote = doubleQuotedAssetPath ? '"' : /'/
+                final String quote = doubleQuotedAssetPath ? '"' : "'"
                 return "${quote}${replacementPath}${quote}"
             }
     }

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
@@ -60,7 +60,7 @@ class HtmlProcessor extends AbstractUrlRewritingProcessor {
                     replacementPath = cachedPaths[trimmedPath] ?: assetPath
                 }
                 else if (trimmedPath.length() > 0 && isRelative(trimmedPath)) {
-                    replacementPath  = replacementUrl(assetFile, trimmedPath)
+                    replacementPath = replacementUrl(assetFile, trimmedPath)
                     if (replacementPath) {
                         cachedPaths[trimmedPath] = replacementPath
                     }
@@ -80,10 +80,10 @@ class HtmlProcessor extends AbstractUrlRewritingProcessor {
     }
 
     @Override
-    protected String digestedNonGenericAssetFileName(final AssetFile file, final AssetFile baseFile, final String fileName) {
+    protected String digestedNonGenericAssetFileName(final AssetFile assetFile, final String fileNameSansExt) {
         return \
-            file.compiledExtension != 'html' \
-                ? "${fileName}-${getByteDigest(new DirectiveProcessor(baseFile.contentType[0], precompiler).compile(file).bytes)}.${file.compiledExtension}"
-                : "${fileName}.${file.compiledExtension}"
+            assetFile.compiledExtension != 'html' \
+                ? "${fileNameSansExt}-${getByteDigest(new DirectiveProcessor(null, precompiler).compile(assetFile).bytes)}.${assetFile.compiledExtension}"
+                : "${fileNameSansExt}.${assetFile.compiledExtension}"
     }
 }

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/utils/net/Urls.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/utils/net/Urls.groovy
@@ -1,6 +1,7 @@
 package asset.pipeline.utils.net
 
 
+import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 
@@ -37,6 +38,18 @@ final class Urls {
      */
     static boolean isRelative(final String url) {
         ! isAbsolute(url)
+    }
+
+
+    /**
+     * @returns <a href="https://tools.ietf.org/html/std66">URI scheme</a>, including trailing colon, if present;
+     * otherwise, returns {@code defaultScheme}, which defaults to {@code null}
+     */
+    static String getSchemeWithColon(final String url, final String defaultScheme = null) {
+        final Matcher m = URL_SCHEME_WITH_COLON_PATTERN.matcher(url)
+        m.find() \
+            ? m.group()
+            : defaultScheme
     }
 
 

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/utils/net/Urls.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/utils/net/Urls.groovy
@@ -14,6 +14,16 @@ final class Urls {
      */
     static final Pattern ABSOLUTE_URL_PATTERN = ~/^(?:\p{L}[\p{L}\d+-.]*:)?\//
 
+    /**
+     * URL starts with a <a href="https://tools.ietf.org/html/std66">URI scheme</a>
+     */
+    static final Pattern URL_SCHEME_WITH_COLON_PATTERN = ~/^\p{L}[\p{L}\d+-.]*:/
+
+    /**
+     * URL starts with a <a href="https://tools.ietf.org/html/std66">URI scheme</a>
+     */
+    static final Pattern URL_SCHEME_SANS_COLON_PATTERN = ~/^\p{L}[\p{L}\d+-.]*(?=:)/
+
 
     /**
      * URL starts with either {@code "/"} or a <a href="https://tools.ietf.org/html/std66">URI scheme</a> followed by {@code "/"}

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/utils/net/Urls.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/utils/net/Urls.groovy
@@ -12,20 +12,20 @@ final class Urls {
     /**
      * URL starts with either {@code "/"} or a <a href="https://tools.ietf.org/html/std66">URI scheme</a> followed by {@code "/"}
      */
-    static final Pattern ABSOLUTE_URL_PATTERN = ~/(?:\/|\p{L}[\p{L}\d+-.]*:[\/]).*/
+    static final Pattern ABSOLUTE_URL_PATTERN = ~/^(?:\p{L}[\p{L}\d+-.]*:)?\//
 
 
     /**
      * URL starts with either {@code "/"} or a <a href="https://tools.ietf.org/html/std66">URI scheme</a> followed by {@code "/"}
      */
-    static isAbsolute(final String url) {
-        ABSOLUTE_URL_PATTERN.matcher(url).matches()
+    static boolean isAbsolute(final String url) {
+        ABSOLUTE_URL_PATTERN.matcher(url).find()
     }
 
     /**
      * URL does not start with either {@code "/"} or a <a href="https://tools.ietf.org/html/std66">URI scheme</a> followed by {@code "/"}
      */
-    static isRelative(final String url) {
+    static boolean isRelative(final String url) {
         ! isAbsolute(url)
     }
 

--- a/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPipelinePlugin.groovy
+++ b/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPipelinePlugin.groovy
@@ -77,11 +77,8 @@ class AssetPipelinePlugin implements Plugin<Project> {
 
             project.tasks.withType(Jar) { Jar bundleTask ->
                 bundleTask.dependsOn assetPrecompileTask
-                bundleTask.from "${project.buildDir}/assets", {
-                    into "assets"
-                    // if(!(bundleTask instanceof War)) {
-                    //     into "META-INF"
-                    // }
+                bundleTask.from defaultConfiguration.compileDir, {
+                  into "assets"
                 }
             }
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 }
 
 subprojects {
-	version = '2.3.7'
+	version = '2.3.8'
 }
 
 apply plugin: 'groovy'


### PR DESCRIPTION
I created an abstract common superclass named `AbstractUrlRewritingProcessor` for both `CssProcessor` & `HtmlProcessor`.

This branch, `UrlRewritingProcessorsCleanup`, was branched from `tags/rel-2.3.8`, so your minor version & gradle changes from that are included in this pull request.

After this pull request has been merged into `master`, then I will create a subsequent pull request for my `asset:` scheme code that allows URLs (including relative, absolute with host, and absolute sans host) to be rewritten, on a URL-by-URL basis, by prepending `asset:` to URLs that should be rewritten.