### PR TITLE
Rewrite relative urls including scheme PLUS fix for bug from 2.4.1

### DIFF
--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
@@ -1,0 +1,68 @@
+package asset.pipeline.processors
+
+
+import asset.pipeline.AbstractProcessor
+import asset.pipeline.AssetCompiler
+import asset.pipeline.AssetFile
+import asset.pipeline.AssetHelper
+import asset.pipeline.DirectiveProcessor
+import asset.pipeline.GenericAssetFile
+
+
+/**
+ * Subclasses iterate over relative asset URLs in a base asset file and
+ * rewrites the URL relative to the base asset file.
+ *
+ * In precompiler mode, the asset URLs are also cache digested.
+ *
+ * @author David Estes
+ * @author Ross Goldberg
+ */
+abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
+
+    AbstractUrlRewritingProcessor(final AssetCompiler precompiler) {
+        super(precompiler)
+    }
+
+
+    protected String relativePathToBaseFile(final AssetFile file, final AssetFile baseFile, final boolean useDigest = false) {
+        final List<String> baseRelativePath = baseFile.parentPath ? baseFile.parentPath.split(AssetHelper.DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
+        final List<String> currRelativePath =     file.parentPath ?     file.parentPath.split(AssetHelper.DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
+
+        int filePathIndex = currRelativePath.size() - 1
+        int baseFileIndex = baseRelativePath.size() - 1
+
+        while (filePathIndex >= 0 && baseFileIndex >= 0 && baseRelativePath[baseFileIndex] == currRelativePath[filePathIndex]) {
+            filePathIndex--
+            baseFileIndex--
+        }
+
+        final List<String> calculatedPath = new ArrayList<>(baseFileIndex + filePathIndex + 3)
+
+        // for each remaining level in the home path, add a ..
+        for (; baseFileIndex >= 0; baseFileIndex--) {
+            calculatedPath << '..'
+        }
+
+        for (; filePathIndex >= 0; filePathIndex--) {
+            calculatedPath << currRelativePath[filePathIndex]
+        }
+
+        final String fileName = AssetHelper.nameWithoutExtension(file.name)
+        if(useDigest) {
+            if(file instanceof GenericAssetFile) {
+                calculatedPath << "${fileName}-${AssetHelper.getByteDigest(file.bytes)}.${AssetHelper.extensionFromURI(file.name)}"
+            } else {
+
+                calculatedPath << "${fileName}-${AssetHelper.getByteDigest(new DirectiveProcessor(file.contentType[0], precompiler).compile(file).bytes)}.${file.compiledExtension}"
+            }
+        } else {
+            if(file instanceof GenericAssetFile) {
+                calculatedPath << file.name
+            } else {
+                calculatedPath << "${fileName}.${file.compiledExtension}"
+            }
+        }
+        return calculatedPath.join(AssetHelper.DIRECTIVE_FILE_SEPARATOR)
+    }
+}

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
@@ -89,7 +89,7 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
 
         // file
         final String fileName = nameWithoutExtension(currFile.name)
-        if(precompiler?.options.enableDigests) {
+        if(precompiler && precompiler.options.enableDigests) {
             if(currFile instanceof GenericAssetFile) {
                 replacementPathSb << fileName << '-' << getByteDigest(currFile.bytes) << '.' << extensionFromURI(currFile.name)
             } else {

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
@@ -30,8 +30,11 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
 
 
     protected String relativePathToBaseFile(final AssetFile currFile, final AssetFile baseFile, final boolean useDigest = false) {
-        final List<String> baseRelativePath = baseFile.parentPath ? baseFile.parentPath.split(DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
-        final List<String> currRelativePath = currFile.parentPath ? currFile.parentPath.split(DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
+        final String baseFileParentPath = baseFile.parentPath
+        final String currFileParentPath = currFile.parentPath
+
+        final List<String> baseRelativePath = baseFileParentPath ? baseFileParentPath.split(DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
+        final List<String> currRelativePath = currFileParentPath ? currFileParentPath.split(DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
 
         int basePathIndex = baseRelativePath.size() - 1
         int currPathIndex = currRelativePath.size() - 1

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
@@ -58,15 +58,15 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
         final String fileName = nameWithoutExtension(currFile.name)
         if(useDigest) {
             if(currFile instanceof GenericAssetFile) {
-                replacementPathSb << "${fileName}-${getByteDigest(currFile.bytes)}.${extensionFromURI(currFile.name)}"
+                replacementPathSb << fileName << '-' << getByteDigest(currFile.bytes) << '.' << extensionFromURI(currFile.name)
             } else {
-                replacementPathSb << "${fileName}-${getByteDigest(new DirectiveProcessor(currFile.contentType[0], precompiler).compile(currFile).bytes)}.${currFile.compiledExtension}"
+                replacementPathSb << fileName << '-' << getByteDigest(new DirectiveProcessor(currFile.contentType[0], precompiler).compile(currFile).bytes) << '.' << currFile.compiledExtension
             }
         } else {
             if(currFile instanceof GenericAssetFile) {
                 replacementPathSb << currFile.name
             } else {
-                replacementPathSb << "${fileName}.${currFile.compiledExtension}"
+                replacementPathSb << fileName << '.' << currFile.compiledExtension
             }
         }
 

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
@@ -30,6 +30,8 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
 
 
     protected String relativePathToBaseFile(final AssetFile currFile, final AssetFile baseFile, final boolean useDigest = false) {
+        final StringBuilder replacementPathSb = new StringBuilder()
+
         final String baseFileParentPath = baseFile.parentPath
         final String currFileParentPath = currFile.parentPath
 
@@ -44,32 +46,30 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
             currPathIndex--
         }
 
-        final List<String> calculatedPath = new ArrayList<>(basePathIndex + currPathIndex + 3)
-
         // for each remaining level in the base path, add a ..
         for (; basePathIndex >= 0; basePathIndex--) {
-            calculatedPath << '..'
+            replacementPathSb << '..' << DIRECTIVE_FILE_SEPARATOR
         }
 
         for (; currPathIndex >= 0; currPathIndex--) {
-            calculatedPath << currRelativePath[currPathIndex]
+            replacementPathSb << currRelativePath[currPathIndex] << DIRECTIVE_FILE_SEPARATOR
         }
 
         final String fileName = nameWithoutExtension(currFile.name)
         if(useDigest) {
             if(currFile instanceof GenericAssetFile) {
-                calculatedPath << "${fileName}-${getByteDigest(currFile.bytes)}.${extensionFromURI(currFile.name)}"
+                replacementPathSb << "${fileName}-${getByteDigest(currFile.bytes)}.${extensionFromURI(currFile.name)}"
             } else {
-                calculatedPath << "${fileName}-${getByteDigest(new DirectiveProcessor(currFile.contentType[0], precompiler).compile(currFile).bytes)}.${currFile.compiledExtension}"
+                replacementPathSb << "${fileName}-${getByteDigest(new DirectiveProcessor(currFile.contentType[0], precompiler).compile(currFile).bytes)}.${currFile.compiledExtension}"
             }
         } else {
             if(currFile instanceof GenericAssetFile) {
-                calculatedPath << currFile.name
+                replacementPathSb << currFile.name
             } else {
-                calculatedPath << "${fileName}.${currFile.compiledExtension}"
+                replacementPathSb << "${fileName}.${currFile.compiledExtension}"
             }
         }
 
-        return calculatedPath.join(DIRECTIVE_FILE_SEPARATOR)
+        return replacementPathSb.toString()
     }
 }

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
@@ -4,9 +4,13 @@ package asset.pipeline.processors
 import asset.pipeline.AbstractProcessor
 import asset.pipeline.AssetCompiler
 import asset.pipeline.AssetFile
-import asset.pipeline.AssetHelper
 import asset.pipeline.DirectiveProcessor
 import asset.pipeline.GenericAssetFile
+
+import static asset.pipeline.AssetHelper.DIRECTIVE_FILE_SEPARATOR
+import static asset.pipeline.AssetHelper.extensionFromURI
+import static asset.pipeline.AssetHelper.getByteDigest
+import static asset.pipeline.AssetHelper.nameWithoutExtension
 
 
 /**
@@ -26,8 +30,8 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
 
 
     protected String relativePathToBaseFile(final AssetFile file, final AssetFile baseFile, final boolean useDigest = false) {
-        final List<String> baseRelativePath = baseFile.parentPath ? baseFile.parentPath.split(AssetHelper.DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
-        final List<String> currRelativePath =     file.parentPath ?     file.parentPath.split(AssetHelper.DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
+        final List<String> baseRelativePath = baseFile.parentPath ? baseFile.parentPath.split(DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
+        final List<String> currRelativePath =     file.parentPath ?     file.parentPath.split(DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
 
         int filePathIndex = currRelativePath.size() - 1
         int baseFileIndex = baseRelativePath.size() - 1
@@ -48,13 +52,12 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
             calculatedPath << currRelativePath[filePathIndex]
         }
 
-        final String fileName = AssetHelper.nameWithoutExtension(file.name)
+        final String fileName = nameWithoutExtension(file.name)
         if(useDigest) {
             if(file instanceof GenericAssetFile) {
-                calculatedPath << "${fileName}-${AssetHelper.getByteDigest(file.bytes)}.${AssetHelper.extensionFromURI(file.name)}"
+                calculatedPath << "${fileName}-${getByteDigest(file.bytes)}.${extensionFromURI(file.name)}"
             } else {
-
-                calculatedPath << "${fileName}-${AssetHelper.getByteDigest(new DirectiveProcessor(file.contentType[0], precompiler).compile(file).bytes)}.${file.compiledExtension}"
+                calculatedPath << "${fileName}-${getByteDigest(new DirectiveProcessor(file.contentType[0], precompiler).compile(file).bytes)}.${file.compiledExtension}"
             }
         } else {
             if(file instanceof GenericAssetFile) {
@@ -63,6 +66,7 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
                 calculatedPath << "${fileName}.${file.compiledExtension}"
             }
         }
-        return calculatedPath.join(AssetHelper.DIRECTIVE_FILE_SEPARATOR)
+
+        return calculatedPath.join(DIRECTIVE_FILE_SEPARATOR)
     }
 }

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
@@ -27,6 +27,14 @@ import static asset.pipeline.utils.net.Urls.getSchemeWithColon
  */
 abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
 
+    private static final Set<String> NO_CACHE_DIGEST_FOR_COMPILED_EXTENSION_SET = []
+
+
+    protected static boolean doNotInsertCacheDigestIntoUrlForCompiledExtension(final String compiledExtension) {
+        NO_CACHE_DIGEST_FOR_COMPILED_EXTENSION_SET.add(compiledExtension)
+    }
+
+
     AbstractUrlRewritingProcessor(final AssetCompiler precompiler) {
         super(precompiler)
     }
@@ -93,7 +101,12 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
             if(currFile instanceof GenericAssetFile) {
                 replacementPathSb << fileName << '-' << getByteDigest(currFile.bytes) << '.' << extensionFromURI(currFile.name)
             } else {
-                replacementPathSb << fileName << '-' << getByteDigest(new DirectiveProcessor(currFile.contentType[0], precompiler).compile(currFile).bytes) << '.' << currFile.compiledExtension
+                final String compiledExtension = currFile.compiledExtension
+                if (NO_CACHE_DIGEST_FOR_COMPILED_EXTENSION_SET.contains(compiledExtension)) {
+                    replacementPathSb << fileName << '.' << compiledExtension
+                } else {
+                    replacementPathSb << fileName << '-' << getByteDigest(new DirectiveProcessor(currFile.contentType[0], precompiler).compile(currFile).bytes) << '.' << compiledExtension
+                }
             }
         } else {
             if(currFile instanceof GenericAssetFile) {

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
@@ -32,15 +32,15 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
 
 
     protected String replacementUrl(final AssetFile assetFile, final String url) {
-        final URL urlSplitter = new URL("http://hostname/${url}") // Split out subcomponents
+        final URL urlSplitter = new URL('http', 'hostname', url)
 
         final AssetFile baseFile = assetFile.baseFile ?: assetFile
         final AssetFile currFile =
             fileForFullName(
                 normalizePath(
                     assetFile.parentPath
-                        ? assetFile.parentPath + urlSplitter.path
-                        : urlSplitter.path.substring(1)
+                        ? assetFile.parentPath + DIRECTIVE_FILE_SEPARATOR + urlSplitter.path
+                        : urlSplitter.path
                 )
             )
 

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
@@ -29,41 +29,41 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
     }
 
 
-    protected String relativePathToBaseFile(final AssetFile file, final AssetFile baseFile, final boolean useDigest = false) {
+    protected String relativePathToBaseFile(final AssetFile currFile, final AssetFile baseFile, final boolean useDigest = false) {
         final List<String> baseRelativePath = baseFile.parentPath ? baseFile.parentPath.split(DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
-        final List<String> currRelativePath =     file.parentPath ?     file.parentPath.split(DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
+        final List<String> currRelativePath = currFile.parentPath ? currFile.parentPath.split(DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
 
-        int filePathIndex = currRelativePath.size() - 1
-        int baseFileIndex = baseRelativePath.size() - 1
+        int currPathIndex = currRelativePath.size() - 1
+        int basePathIndex = baseRelativePath.size() - 1
 
-        while (filePathIndex >= 0 && baseFileIndex >= 0 && baseRelativePath[baseFileIndex] == currRelativePath[filePathIndex]) {
-            filePathIndex--
-            baseFileIndex--
+        while (currPathIndex >= 0 && basePathIndex >= 0 && baseRelativePath[basePathIndex] == currRelativePath[currPathIndex]) {
+            currPathIndex--
+            basePathIndex--
         }
 
-        final List<String> calculatedPath = new ArrayList<>(baseFileIndex + filePathIndex + 3)
+        final List<String> calculatedPath = new ArrayList<>(basePathIndex + currPathIndex + 3)
 
-        // for each remaining level in the home path, add a ..
-        for (; baseFileIndex >= 0; baseFileIndex--) {
+        // for each remaining level in the base path, add a ..
+        for (; basePathIndex >= 0; basePathIndex--) {
             calculatedPath << '..'
         }
 
-        for (; filePathIndex >= 0; filePathIndex--) {
-            calculatedPath << currRelativePath[filePathIndex]
+        for (; currPathIndex >= 0; currPathIndex--) {
+            calculatedPath << currRelativePath[currPathIndex]
         }
 
-        final String fileName = nameWithoutExtension(file.name)
+        final String fileName = nameWithoutExtension(currFile.name)
         if(useDigest) {
-            if(file instanceof GenericAssetFile) {
-                calculatedPath << "${fileName}-${getByteDigest(file.bytes)}.${extensionFromURI(file.name)}"
+            if(currFile instanceof GenericAssetFile) {
+                calculatedPath << "${fileName}-${getByteDigest(currFile.bytes)}.${extensionFromURI(currFile.name)}"
             } else {
-                calculatedPath << "${fileName}-${getByteDigest(new DirectiveProcessor(file.contentType[0], precompiler).compile(file).bytes)}.${file.compiledExtension}"
+                calculatedPath << "${fileName}-${getByteDigest(new DirectiveProcessor(currFile.contentType[0], precompiler).compile(currFile).bytes)}.${currFile.compiledExtension}"
             }
         } else {
-            if(file instanceof GenericAssetFile) {
-                calculatedPath << file.name
+            if(currFile instanceof GenericAssetFile) {
+                calculatedPath << currFile.name
             } else {
-                calculatedPath << "${fileName}.${file.compiledExtension}"
+                calculatedPath << "${fileName}.${currFile.compiledExtension}"
             }
         }
 

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
@@ -13,6 +13,7 @@ import static asset.pipeline.AssetHelper.fileForFullName
 import static asset.pipeline.AssetHelper.getByteDigest
 import static asset.pipeline.AssetHelper.nameWithoutExtension
 import static asset.pipeline.AssetHelper.normalizePath
+import static asset.pipeline.utils.net.Urls.getSchemeWithColon
 
 
 /**
@@ -32,7 +33,14 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
 
 
     protected String replacementUrl(final AssetFile assetFile, final String url) {
-        final URL urlSplitter = new URL('http', 'hostname', url)
+        final String schemeWithColon = getSchemeWithColon(url)
+
+        final String urlSansScheme =
+            schemeWithColon \
+                ? url.substring(schemeWithColon.length())
+                : url
+
+        final URL urlSplitter = new URL('http', 'hostname', urlSansScheme)
 
         final AssetFile baseFile = assetFile.baseFile ?: assetFile
         final AssetFile currFile =
@@ -49,6 +57,11 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
         }
 
         final StringBuilder replacementPathSb = new StringBuilder()
+
+        // scheme (aka protocol)
+        if (schemeWithColon) {
+            replacementPathSb << schemeWithColon
+        }
 
         // relative parent path
         final String baseFileParentPath = baseFile.parentPath

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
@@ -33,12 +33,12 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
         final List<String> baseRelativePath = baseFile.parentPath ? baseFile.parentPath.split(DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
         final List<String> currRelativePath = currFile.parentPath ? currFile.parentPath.split(DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
 
-        int currPathIndex = currRelativePath.size() - 1
         int basePathIndex = baseRelativePath.size() - 1
+        int currPathIndex = currRelativePath.size() - 1
 
-        while (currPathIndex >= 0 && basePathIndex >= 0 && baseRelativePath[basePathIndex] == currRelativePath[currPathIndex]) {
-            currPathIndex--
+        while (basePathIndex >= 0 && currPathIndex >= 0 && baseRelativePath[basePathIndex] == currRelativePath[currPathIndex]) {
             basePathIndex--
+            currPathIndex--
         }
 
         final List<String> calculatedPath = new ArrayList<>(basePathIndex + currPathIndex + 3)

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/AbstractUrlRewritingProcessor.groovy
@@ -32,6 +32,7 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
     protected String relativePathToBaseFile(final AssetFile currFile, final AssetFile baseFile, final boolean useDigest = false) {
         final StringBuilder replacementPathSb = new StringBuilder()
 
+        // relative parent path
         final String baseFileParentPath = baseFile.parentPath
         final String currFileParentPath = currFile.parentPath
 
@@ -55,6 +56,7 @@ abstract class AbstractUrlRewritingProcessor extends AbstractProcessor {
             replacementPathSb << currRelativePath[currPathIndex] << DIRECTIVE_FILE_SEPARATOR
         }
 
+        // file
         final String fileName = nameWithoutExtension(currFile.name)
         if(useDigest) {
             if(currFile instanceof GenericAssetFile) {

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/CssProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/CssProcessor.groovy
@@ -55,9 +55,14 @@ class CssProcessor extends AbstractUrlRewritingProcessor {
                 } else if (assetPath.size() > 0 && isRelative(assetPath)) {
                     final URL urlSplitter = new URL("http://hostname/${assetPath}") // Split out subcomponents
 
-                    final String relativeFileName = assetFile.parentPath ? assetFile.parentPath + urlSplitter.path : urlSplitter.path.substring(1)
-
-                    final AssetFile file = fileForFullName(normalizePath(relativeFileName))
+                    final AssetFile file =
+                        fileForFullName(
+                            normalizePath(
+                                assetFile.parentPath
+                                    ? assetFile.parentPath + urlSplitter.path
+                                    : urlSplitter.path.substring(1)
+                            )
+                        )
 
                     if (file) {
                         final StringBuilder replacementPathSb = new StringBuilder()

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/CssProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/CssProcessor.groovy
@@ -20,8 +20,6 @@ import asset.pipeline.AssetCompiler
 import asset.pipeline.AssetFile
 import java.util.regex.Pattern
 
-import static asset.pipeline.AssetHelper.fileForFullName
-import static asset.pipeline.AssetHelper.normalizePath
 import static asset.pipeline.utils.net.Urls.isRelative
 
 
@@ -53,27 +51,8 @@ class CssProcessor extends AbstractUrlRewritingProcessor {
                 if (cachedPath != null) {
                     replacementPath = cachedPath
                 } else if (assetPath.size() > 0 && isRelative(assetPath)) {
-                    final URL urlSplitter = new URL("http://hostname/${assetPath}") // Split out subcomponents
-
-                    final AssetFile currFile =
-                        fileForFullName(
-                            normalizePath(
-                                assetFile.parentPath
-                                    ? assetFile.parentPath + urlSplitter.path
-                                    : urlSplitter.path.substring(1)
-                            )
-                        )
-
-                    if (currFile) {
-                        final StringBuilder replacementPathSb = new StringBuilder()
-                        replacementPathSb.append(relativePathToBaseFile(currFile, assetFile.baseFile ?: assetFile, precompiler && precompiler.options.enableDigests))
-                        if (urlSplitter.query != null) {
-                            replacementPathSb.append('?').append(urlSplitter.query)
-                        }
-                        if (urlSplitter.ref) {
-                            replacementPathSb.append('#').append(urlSplitter.ref)
-                        }
-                        replacementPath        = replacementPathSb.toString()
+                    replacementPath = replacementUrl(assetFile, assetPath)
+                    if (replacementPath) {
                         cachedPaths[assetPath] = replacementPath
                     } else {
                         cachedPaths[assetPath] = assetPath

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/CssProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/CssProcessor.groovy
@@ -18,9 +18,10 @@ package asset.pipeline.processors
 
 import asset.pipeline.AssetCompiler
 import asset.pipeline.AssetFile
-import asset.pipeline.AssetHelper
 import java.util.regex.Pattern
 
+import static asset.pipeline.AssetHelper.fileForFullName
+import static asset.pipeline.AssetHelper.normalizePath
 import static asset.pipeline.utils.net.Urls.isRelative
 
 
@@ -52,18 +53,20 @@ class CssProcessor extends AbstractUrlRewritingProcessor {
                 if (cachedPath != null) {
                     replacementPath = cachedPath
                 } else if (assetPath.size() > 0 && isRelative(assetPath)) {
-                    final URL       url              = new URL("http://hostname/${assetPath}") // Split out subcomponents
-                    final String    relativeFileName = assetFile.parentPath ? assetFile.parentPath + url.path : url.path.substring(1)
-                    final AssetFile file             = AssetHelper.fileForFullName(AssetHelper.normalizePath(relativeFileName))
+                    final URL urlSplitter = new URL("http://hostname/${assetPath}") // Split out subcomponents
+
+                    final String relativeFileName = assetFile.parentPath ? assetFile.parentPath + urlSplitter.path : urlSplitter.path.substring(1)
+
+                    final AssetFile file = fileForFullName(normalizePath(relativeFileName))
 
                     if (file) {
                         final StringBuilder replacementPathSb = new StringBuilder()
                         replacementPathSb.append(relativePathToBaseFile(file, assetFile.baseFile ?: assetFile, precompiler && precompiler.options.enableDigests))
-                        if (url.query != null) {
-                            replacementPathSb.append('?').append(url.query)
+                        if (urlSplitter.query != null) {
+                            replacementPathSb.append('?').append(urlSplitter.query)
                         }
-                        if (url.ref) {
-                            replacementPathSb.append('#').append(url.ref)
+                        if (urlSplitter.ref) {
+                            replacementPathSb.append('#').append(urlSplitter.ref)
                         }
                         replacementPath        = replacementPathSb.toString()
                         cachedPaths[assetPath] = replacementPath

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/CssProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/CssProcessor.groovy
@@ -16,12 +16,9 @@
 package asset.pipeline.processors
 
 
-import asset.pipeline.AbstractProcessor
 import asset.pipeline.AssetCompiler
 import asset.pipeline.AssetFile
 import asset.pipeline.AssetHelper
-import asset.pipeline.DirectiveProcessor
-import asset.pipeline.GenericAssetFile
 import java.util.regex.Pattern
 
 import static asset.pipeline.utils.net.Urls.isRelative
@@ -35,7 +32,7 @@ import static asset.pipeline.utils.net.Urls.isRelative
  * @author David Estes
  * @author Ross Goldberg
  */
-class CssProcessor extends AbstractProcessor {
+class CssProcessor extends AbstractUrlRewritingProcessor {
 
     private static final Pattern URL_CALL_PATTERN = ~/url\((?:\s*)(['"]?)([a-zA-Z0-9\-_.\/@#? &+%=]++)\1?(?:\s*)\)/
 
@@ -80,46 +77,5 @@ class CssProcessor extends AbstractProcessor {
 
                 return "url(${quote}${replacementPath}${quote})"
             }
-    }
-
-    private String relativePathToBaseFile(final AssetFile file, final AssetFile baseFile, final boolean useDigest = false) {
-        final List<String> baseRelativePath = baseFile.parentPath ? baseFile.parentPath.split(AssetHelper.DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
-        final List<String> currRelativePath =     file.parentPath ?     file.parentPath.split(AssetHelper.DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
-
-        int filePathIndex = currRelativePath.size() - 1
-        int baseFileIndex = baseRelativePath.size() - 1
-
-        while (filePathIndex >= 0 && baseFileIndex >= 0 && baseRelativePath[baseFileIndex] == currRelativePath[filePathIndex]) {
-            filePathIndex--
-            baseFileIndex--
-        }
-
-        final List<String> calculatedPath = new ArrayList<>(baseFileIndex + filePathIndex + 3)
-
-        // for each remaining level in the home path, add a ..
-        for (; baseFileIndex >= 0; baseFileIndex--) {
-            calculatedPath << '..'
-        }
-
-        for (; filePathIndex >= 0; filePathIndex--) {
-            calculatedPath << currRelativePath[filePathIndex]
-        }
-
-        final String fileName = AssetHelper.nameWithoutExtension(file.name)
-        if(useDigest) {
-            if(file instanceof GenericAssetFile) {
-                calculatedPath << "${fileName}-${AssetHelper.getByteDigest(file.bytes)}.${AssetHelper.extensionFromURI(file.name)}"
-            } else {
-
-                calculatedPath << "${fileName}-${AssetHelper.getByteDigest(new DirectiveProcessor(file.contentType[0], precompiler).compile(file).bytes)}.${file.compiledExtension}"
-            }
-        } else {
-            if(file instanceof GenericAssetFile) {
-                calculatedPath << file.name
-            } else {
-                calculatedPath << "${fileName}.${file.compiledExtension}"
-            }
-        }
-        return calculatedPath.join(AssetHelper.DIRECTIVE_FILE_SEPARATOR)
     }
 }

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/CssProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/CssProcessor.groovy
@@ -55,7 +55,7 @@ class CssProcessor extends AbstractUrlRewritingProcessor {
                 } else if (assetPath.size() > 0 && isRelative(assetPath)) {
                     final URL urlSplitter = new URL("http://hostname/${assetPath}") // Split out subcomponents
 
-                    final AssetFile file =
+                    final AssetFile currFile =
                         fileForFullName(
                             normalizePath(
                                 assetFile.parentPath
@@ -64,9 +64,9 @@ class CssProcessor extends AbstractUrlRewritingProcessor {
                             )
                         )
 
-                    if (file) {
+                    if (currFile) {
                         final StringBuilder replacementPathSb = new StringBuilder()
-                        replacementPathSb.append(relativePathToBaseFile(file, assetFile.baseFile ?: assetFile, precompiler && precompiler.options.enableDigests))
+                        replacementPathSb.append(relativePathToBaseFile(currFile, assetFile.baseFile ?: assetFile, precompiler && precompiler.options.enableDigests))
                         if (urlSplitter.query != null) {
                             replacementPathSb.append('?').append(urlSplitter.query)
                         }

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/CssProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/CssProcessor.groovy
@@ -33,7 +33,7 @@ import static asset.pipeline.utils.net.Urls.isRelative
  */
 class CssProcessor extends AbstractUrlRewritingProcessor {
 
-    private static final Pattern URL_CALL_PATTERN = ~/url\((?:\s*)(['"]?)([a-zA-Z0-9\-_.\/@#? &+%=]++)\1?(?:\s*)\)/
+    private static final Pattern URL_CALL_PATTERN = ~/url\((?:\s*)(['"]?)([a-zA-Z0-9\-_.:\/@#? &+%=]++)\1?(?:\s*)\)/
 
 
     CssProcessor(final AssetCompiler precompiler) {

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
@@ -20,8 +20,6 @@ import asset.pipeline.AssetCompiler
 import asset.pipeline.AssetFile
 import java.util.regex.Pattern
 
-import static asset.pipeline.AssetHelper.fileForFullName
-import static asset.pipeline.AssetHelper.normalizePath
 import static asset.pipeline.utils.net.Urls.isRelative
 
 
@@ -59,27 +57,8 @@ class HtmlProcessor extends AbstractUrlRewritingProcessor {
                     // cachedPaths[assetPath] == null // means use the incoming untrimmedAssetPath to preserve trim spacing
                     replacementPath = cachedPaths[assetPath] ?: untrimmedAssetPath
                 } else if (assetPath.size() > 0 && isRelative(assetPath)) {
-                    final URL urlSplitter = new URL("http://hostname/${assetPath}") // Split out subcomponents
-
-                    final AssetFile currFile =
-                        fileForFullName(
-                            normalizePath(
-                                assetFile.parentPath
-                                    ? assetFile.parentPath + urlSplitter.path
-                                    : urlSplitter.path.substring(1)
-                            )
-                        )
-
-                    if (currFile) {
-                        final StringBuilder replacementPathSb = new StringBuilder()
-                        replacementPathSb.append(relativePathToBaseFile(currFile, assetFile.baseFile ?: assetFile, precompiler && precompiler.options.enableDigests))
-                        if (urlSplitter.query != null) {
-                            replacementPathSb.append('?').append(urlSplitter.query)
-                        }
-                        if (urlSplitter.ref) {
-                            replacementPathSb.append('#').append(urlSplitter.ref)
-                        }
-                        replacementPath        = replacementPathSb.toString()
+                    replacementPath = replacementUrl(assetFile, assetPath)
+                    if (replacementPath) {
                         cachedPaths[assetPath] = replacementPath
                     } else {
                         cachedPaths[assetPath] = null
@@ -90,7 +69,7 @@ class HtmlProcessor extends AbstractUrlRewritingProcessor {
                     return quotedAssetPathWithQuotes
                 }
 
-                final String quote = doubleQuotedAssetPath ? '"' : /'/
+                final String quote = doubleQuotedAssetPath ? '"' : "'"
                 return "${quote}${replacementPath}${quote}"
             }
     }

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
@@ -35,6 +35,10 @@ class HtmlProcessor extends AbstractUrlRewritingProcessor {
 
     private static final Pattern QUOTED_ASSET_PATH_PATTERN = ~/"([a-zA-Z0-9\-_.:\/@#? &+%=']++)"|'([a-zA-Z0-9\-_.:\/@#? &+%="]++)'/
 
+    static {
+        doNotInsertCacheDigestIntoUrlForCompiledExtension('html')
+    }
+
 
     HtmlProcessor(final AssetCompiler precompiler) {
         super(precompiler)

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
@@ -16,12 +16,9 @@
 package asset.pipeline.processors
 
 
-import asset.pipeline.AbstractProcessor
 import asset.pipeline.AssetCompiler
 import asset.pipeline.AssetFile
 import asset.pipeline.AssetHelper
-import asset.pipeline.DirectiveProcessor
-import asset.pipeline.GenericAssetFile
 import java.util.regex.Pattern
 
 import static asset.pipeline.utils.net.Urls.isRelative
@@ -35,7 +32,7 @@ import static asset.pipeline.utils.net.Urls.isRelative
  * @author David Estes
  * @author Ross Goldberg
  */
-class HtmlProcessor extends AbstractProcessor {
+class HtmlProcessor extends AbstractUrlRewritingProcessor {
 
     private static final Pattern QUOTED_ASSET_PATH_PATTERN = ~/"([a-zA-Z0-9\-_.\/@#? &+%=']++)"|'([a-zA-Z0-9\-_.\/@#? &+%="]++)'/
 
@@ -91,47 +88,5 @@ class HtmlProcessor extends AbstractProcessor {
                 final String quote = doubleQuotedAssetPath ? '"' : /'/
                 return "${quote}${replacementPath}${quote}"
             }
-    }
-
-    private String relativePathToBaseFile(final AssetFile file, final AssetFile baseFile, final boolean useDigest = false) {
-        final List<String> baseRelativePath = baseFile.parentPath ? baseFile.parentPath.split(AssetHelper.DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
-        final List<String> currRelativePath =     file.parentPath ?     file.parentPath.split(AssetHelper.DIRECTIVE_FILE_SEPARATOR).findAll {it}.reverse() : []
-
-        int filePathIndex = currRelativePath.size() - 1
-        int baseFileIndex = baseRelativePath.size() - 1
-
-        while (filePathIndex >= 0 && baseFileIndex >= 0 && baseRelativePath[baseFileIndex] == currRelativePath[filePathIndex]) {
-            filePathIndex--
-            baseFileIndex--
-        }
-
-        final List<String> calculatedPath = new ArrayList<>(baseFileIndex + filePathIndex + 3)
-
-        // for each remaining level in the home path, add a ..
-        for (; baseFileIndex >= 0; baseFileIndex--) {
-            calculatedPath << '..'
-        }
-
-        for (; filePathIndex >= 0; filePathIndex--) {
-            calculatedPath << currRelativePath[filePathIndex]
-        }
-
-        final String fileName = AssetHelper.nameWithoutExtension(file.name)
-        if(useDigest) {
-            if(file instanceof GenericAssetFile) {
-                calculatedPath << "${fileName}-${AssetHelper.getByteDigest(file.bytes)}.${AssetHelper.extensionFromURI(file.name)}"
-            } else {
-
-                calculatedPath << "${fileName}-${AssetHelper.getByteDigest(new DirectiveProcessor(file.contentType[0], precompiler).compile(file).bytes)}.${file.compiledExtension}"
-            }
-        } else {
-            if(file instanceof GenericAssetFile) {
-                calculatedPath << file.name
-            } else {
-                calculatedPath << "${fileName}.${file.compiledExtension}"
-            }
-        }
-
-        return calculatedPath.join(AssetHelper.DIRECTIVE_FILE_SEPARATOR)
     }
 }

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
@@ -61,9 +61,14 @@ class HtmlProcessor extends AbstractUrlRewritingProcessor {
                 } else if (assetPath.size() > 0 && isRelative(assetPath)) {
                     final URL urlSplitter = new URL("http://hostname/${assetPath}") // Split out subcomponents
 
-                    final String relativeFileName = assetFile.parentPath ? assetFile.parentPath + urlSplitter.path : urlSplitter.path.substring(1)
-
-                    final AssetFile file = fileForFullName(normalizePath(relativeFileName))
+                    final AssetFile file =
+                        fileForFullName(
+                            normalizePath(
+                                assetFile.parentPath
+                                    ? assetFile.parentPath + urlSplitter.path
+                                    : urlSplitter.path.substring(1)
+                            )
+                        )
 
                     if (file) {
                         final StringBuilder replacementPathSb = new StringBuilder()

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
@@ -61,7 +61,7 @@ class HtmlProcessor extends AbstractUrlRewritingProcessor {
                 } else if (assetPath.size() > 0 && isRelative(assetPath)) {
                     final URL urlSplitter = new URL("http://hostname/${assetPath}") // Split out subcomponents
 
-                    final AssetFile file =
+                    final AssetFile currFile =
                         fileForFullName(
                             normalizePath(
                                 assetFile.parentPath
@@ -70,9 +70,9 @@ class HtmlProcessor extends AbstractUrlRewritingProcessor {
                             )
                         )
 
-                    if (file) {
+                    if (currFile) {
                         final StringBuilder replacementPathSb = new StringBuilder()
-                        replacementPathSb.append(relativePathToBaseFile(file, assetFile.baseFile ?: assetFile, precompiler && precompiler.options.enableDigests))
+                        replacementPathSb.append(relativePathToBaseFile(currFile, assetFile.baseFile ?: assetFile, precompiler && precompiler.options.enableDigests))
                         if (urlSplitter.query != null) {
                             replacementPathSb.append('?').append(urlSplitter.query)
                         }

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
@@ -50,16 +50,15 @@ class HtmlProcessor extends AbstractUrlRewritingProcessor {
                 final String doubleQuotedAssetPath,
                 final String singleQuotedAssetPath
             ->
-                final String assetPath   = doubleQuotedAssetPath ?: singleQuotedAssetPath
-                final String trimmedPath = assetPath.trim()
+                final String untrimmedAssetPath = doubleQuotedAssetPath ?: singleQuotedAssetPath
+                final String assetPath          = untrimmedAssetPath.trim()
 
                 final String replacementPath
-                if (cachedPaths.containsKey(trimmedPath)) {
-                    // cachedPaths[trimmedPath] == null // means use the incoming assetPath to preserve trim spacing
-                    replacementPath = cachedPaths[trimmedPath] ?: assetPath
-                }
-                else if (trimmedPath.size() > 0 && isRelative(trimmedPath)) {
-                    final URL       url              = new URL("http://hostname/${trimmedPath}") // Split out subcomponents
+                if (cachedPaths.containsKey(assetPath)) {
+                    // cachedPaths[assetPath] == null // means use the incoming untrimmedAssetPath to preserve trim spacing
+                    replacementPath = cachedPaths[assetPath] ?: untrimmedAssetPath
+                } else if (assetPath.size() > 0 && isRelative(assetPath)) {
+                    final URL       url              = new URL("http://hostname/${assetPath}") // Split out subcomponents
                     final String    relativeFileName = assetFile.parentPath ? assetFile.parentPath + url.path : url.path.substring(1)
                     final AssetFile file             = AssetHelper.fileForFullName(AssetHelper.normalizePath(relativeFileName))
 
@@ -72,16 +71,14 @@ class HtmlProcessor extends AbstractUrlRewritingProcessor {
                         if (url.ref) {
                             replacementPathSb.append('#').append(url.ref)
                         }
-                        replacementPath          = replacementPathSb.toString()
-                        cachedPaths[trimmedPath] = replacementPath
-                    }
-                    else {
-                        cachedPaths[trimmedPath] = null
+                        replacementPath        = replacementPathSb.toString()
+                        cachedPaths[assetPath] = replacementPath
+                    } else {
+                        cachedPaths[assetPath] = null
                         return quotedAssetPathWithQuotes
                     }
-                }
-                else {
-                    //TODO? cachedPaths[trimmedPath] = null
+                } else {
+                    //TODO? cachedPaths[assetPath] = null
                     return quotedAssetPathWithQuotes
                 }
 

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
@@ -33,7 +33,7 @@ import static asset.pipeline.utils.net.Urls.isRelative
  */
 class HtmlProcessor extends AbstractUrlRewritingProcessor {
 
-    private static final Pattern QUOTED_ASSET_PATH_PATTERN = ~/"([a-zA-Z0-9\-_.\/@#? &+%=']++)"|'([a-zA-Z0-9\-_.\/@#? &+%="]++)'/
+    private static final Pattern QUOTED_ASSET_PATH_PATTERN = ~/"([a-zA-Z0-9\-_.:\/@#? &+%=']++)"|'([a-zA-Z0-9\-_.:\/@#? &+%="]++)'/
 
 
     HtmlProcessor(final AssetCompiler precompiler) {

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/HtmlProcessor.groovy
@@ -18,9 +18,10 @@ package asset.pipeline.processors
 
 import asset.pipeline.AssetCompiler
 import asset.pipeline.AssetFile
-import asset.pipeline.AssetHelper
 import java.util.regex.Pattern
 
+import static asset.pipeline.AssetHelper.fileForFullName
+import static asset.pipeline.AssetHelper.normalizePath
 import static asset.pipeline.utils.net.Urls.isRelative
 
 
@@ -58,18 +59,20 @@ class HtmlProcessor extends AbstractUrlRewritingProcessor {
                     // cachedPaths[assetPath] == null // means use the incoming untrimmedAssetPath to preserve trim spacing
                     replacementPath = cachedPaths[assetPath] ?: untrimmedAssetPath
                 } else if (assetPath.size() > 0 && isRelative(assetPath)) {
-                    final URL       url              = new URL("http://hostname/${assetPath}") // Split out subcomponents
-                    final String    relativeFileName = assetFile.parentPath ? assetFile.parentPath + url.path : url.path.substring(1)
-                    final AssetFile file             = AssetHelper.fileForFullName(AssetHelper.normalizePath(relativeFileName))
+                    final URL urlSplitter = new URL("http://hostname/${assetPath}") // Split out subcomponents
+
+                    final String relativeFileName = assetFile.parentPath ? assetFile.parentPath + urlSplitter.path : urlSplitter.path.substring(1)
+
+                    final AssetFile file = fileForFullName(normalizePath(relativeFileName))
 
                     if (file) {
                         final StringBuilder replacementPathSb = new StringBuilder()
                         replacementPathSb.append(relativePathToBaseFile(file, assetFile.baseFile ?: assetFile, precompiler && precompiler.options.enableDigests))
-                        if (url.query != null) {
-                            replacementPathSb.append('?').append(url.query)
+                        if (urlSplitter.query != null) {
+                            replacementPathSb.append('?').append(urlSplitter.query)
                         }
-                        if (url.ref) {
-                            replacementPathSb.append('#').append(url.ref)
+                        if (urlSplitter.ref) {
+                            replacementPathSb.append('#').append(urlSplitter.ref)
                         }
                         replacementPath        = replacementPathSb.toString()
                         cachedPaths[assetPath] = replacementPath

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/utils/net/Urls.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/utils/net/Urls.groovy
@@ -1,6 +1,7 @@
 package asset.pipeline.utils.net
 
 
+import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 
@@ -13,6 +14,16 @@ final class Urls {
      * URL starts with either {@code "/"} or a <a href="https://tools.ietf.org/html/std66">URI scheme</a> followed by {@code "/"}
      */
     static final Pattern ABSOLUTE_URL_PATTERN = ~/^(?:\p{L}[\p{L}\d+-.]*:)?\//
+
+    /**
+     * URL starts with a <a href="https://tools.ietf.org/html/std66">URI scheme</a>
+     */
+    static final Pattern URL_SCHEME_WITH_COLON_PATTERN = ~/^\p{L}[\p{L}\d+-.]*:/
+
+    /**
+     * URL starts with a <a href="https://tools.ietf.org/html/std66">URI scheme</a>
+     */
+    static final Pattern URL_SCHEME_SANS_COLON_PATTERN = ~/^\p{L}[\p{L}\d+-.]*(?=:)/
 
 
     /**
@@ -27,6 +38,18 @@ final class Urls {
      */
     static boolean isRelative(final String url) {
         ! isAbsolute(url)
+    }
+
+
+    /**
+     * @returns <a href="https://tools.ietf.org/html/std66">URI scheme</a>, including trailing colon, if present;
+     * otherwise, returns {@code defaultScheme}, which defaults to {@code null}
+     */
+    static String getSchemeWithColon(final String url, final String defaultScheme = null) {
+        final Matcher m = URL_SCHEME_WITH_COLON_PATTERN.matcher(url)
+        m.find() \
+            ? m.group()
+            : defaultScheme
     }
 
 

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/utils/net/Urls.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/utils/net/Urls.groovy
@@ -12,20 +12,20 @@ final class Urls {
     /**
      * URL starts with either {@code "/"} or a <a href="https://tools.ietf.org/html/std66">URI scheme</a> followed by {@code "/"}
      */
-    static final Pattern ABSOLUTE_URL_PATTERN = ~/(?:\/|\p{L}[\p{L}\d+-.]*:[\/]).*/
+    static final Pattern ABSOLUTE_URL_PATTERN = ~/^(?:\p{L}[\p{L}\d+-.]*:)?\//
 
 
     /**
      * URL starts with either {@code "/"} or a <a href="https://tools.ietf.org/html/std66">URI scheme</a> followed by {@code "/"}
      */
-    static isAbsolute(final String url) {
-        ABSOLUTE_URL_PATTERN.matcher(url).matches()
+    static boolean isAbsolute(final String url) {
+        ABSOLUTE_URL_PATTERN.matcher(url).find()
     }
 
     /**
      * URL does not start with either {@code "/"} or a <a href="https://tools.ietf.org/html/std66">URI scheme</a> followed by {@code "/"}
      */
-    static isRelative(final String url) {
+    static boolean isRelative(final String url) {
         ! isAbsolute(url)
     }
 


### PR DESCRIPTION
This branch rewrites relative URLs that include a scheme, like:

    https:relative/path/to/asset.js

I also revamped the existing code, mainly to remove duplicate code, and to make everything more consistent & readable.

This branch also fixes a bug in `HtmlProcessor` that was introduced in `rel-2.4.1`:

In the pre-2.4.1 `HtmlProcessor`, if `enableDigests == true` (which is always the case for the Grails plugin), and if a URL points to an asset with a `compiledExtension == 'html'`, the code would not include the cache digest in the rewritten URL because you could have circular URL references from one html asset to another (possibly through intermediary assets), so you can get an infinite loop & a `StackOverflowError`.

I noticed the bug when I tested my changes in this branch, so I added a fix as the last commit in this branch.

My fix is to have a registry of `compiledExtension`s that shouldn't have cache digests inserted into URLs to them.

`HtmlProcessor` adds `'html'` to this registry.  Other `AbstractUrlRewritingProcessor` subclasses can also add to this registry, but, for safety's sake, nothing can remove compiled extensions from this registry.

There shouldn't be any other functional changes other than the aforementioned ability to rewrite relative asset URLs with scheme prefixes, and the bug fix for the circular reference issue from `rel-2.4.1`.

I made a lot of little commits, so that you could easily step through the commits one-by-one, and see that the code transformations are OK, rather than you having to compare the existing version of the code with one commit in which everything suddenly changed.

There was one bug that I introduced along the way but then fixed in the second-to-last commit in this branch, which was that the existing code ran:

    precompiler && precompiler.options.enableDigests

which I changed to:

    precompiler?.options.enableDigests

But the latter version could throw a NullPointerException, so I reverted it back to the original version.

My subsequent code to support the `asset:` scheme for rewriting specific absolute asset URLs is based on the changes from this branch, so I'll submit a pull request for those changes once this has been merged into default.