### PR TITLE
fixed AssetCompile#setEnableSourceMaps(boolean)

### DIFF
--- a/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetCompile.groovy
+++ b/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetCompile.groovy
@@ -1,7 +1,6 @@
 package asset.pipeline.gradle
 
 import asset.pipeline.AssetCompiler
-import asset.pipeline.AssetHelper
 import asset.pipeline.AssetPipelineConfigHolder
 import asset.pipeline.AssetSpecLoader
 import asset.pipeline.fs.FileSystemAssetResolver
@@ -9,7 +8,6 @@ import asset.pipeline.fs.JarAssetResolver
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
-import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.FileTree
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
@@ -43,7 +41,7 @@ import org.gradle.api.file.FileCollection
 class AssetCompile extends DefaultTask {
 
     @Delegate AssetPipelineExtension pipelineExtension = new AssetPipelineExtension()
-    private FileCollection classpath;
+    //private FileCollection classpath;
 
     @OutputDirectory
     File getDestinationDir() {
@@ -89,7 +87,7 @@ class AssetCompile extends DefaultTask {
         pipelineExtension.enableSourceMaps
     }
 
-    void setEnableSourceMaps(boolean enableGzip) {
+    void setEnableSourceMaps(boolean enableSourceMaps) {
         pipelineExtension.enableSourceMaps = enableSourceMaps
     }
 
@@ -121,6 +119,11 @@ class AssetCompile extends DefaultTask {
         pipelineExtension.minifyCss
     }
 
+    void setMinifyCss(boolean minifyCss) {
+        pipelineExtension.minifyCss = minifyCss
+    }
+
+
     @Input
     @Optional
     Map getConfigOptions() {
@@ -131,9 +134,6 @@ class AssetCompile extends DefaultTask {
         pipelineExtension.configOptions = configOptions
     }
 
-    void setMinifyCss(boolean minifyCss) {
-        pipelineExtension.minifyCss = minifyCss
-    }
 
     @InputFiles
     @Optional
@@ -168,13 +168,13 @@ class AssetCompile extends DefaultTask {
         // println "Compiling assets in directory ${assetsDir}"
         def resolver = new FileSystemAssetResolver('application', assetsDir.canonicalPath)
         AssetPipelineConfigHolder.registerResolver(resolver)
-        
+
         //Time to register Jar Resolvers
         this.getClasspath()?.files?.each { file ->
             if(file.exists()) {
                 AssetPipelineConfigHolder.registerResolver(new JarAssetResolver(file.name,file.canonicalPath,"META-INF/assets"))
                 AssetPipelineConfigHolder.registerResolver(new JarAssetResolver(file.name,file.canonicalPath,"META-INF/static"))
-                AssetPipelineConfigHolder.registerResolver(new JarAssetResolver(file.name,file.canonicalPath,"META-INF/resources"))    
+                AssetPipelineConfigHolder.registerResolver(new JarAssetResolver(file.name,file.canonicalPath,"META-INF/resources"))
             }
         }
 
@@ -188,15 +188,14 @@ class AssetCompile extends DefaultTask {
 
     void loadAssetSpecifications() {
         Set<File> processorFiles = project.configurations.getByName(AssetPipelinePlugin.ASSET_CONFIGURATION_NAME)?.files
-        
+
         if (processorFiles) {
             URL[] urls = processorFiles.collect { it.toURI().toURL() }
-            ClassLoader classLoader = new URLClassLoader(urls as URL[], getClass().classLoader)            
+            ClassLoader classLoader = new URLClassLoader(urls as URL[], getClass().classLoader)
             AssetSpecLoader.loadSpecifications(classLoader)
         }
         else {
             AssetSpecLoader.loadSpecifications()
         }
     }
-
 }


### PR DESCRIPTION
`AssetCompile`:

fixed `setEnableSourceMaps(boolean)`
renamed incorrectly named method parameter from `enableGzip` to `enableSourceMaps`

moved `setMinifyCss(boolean)` to be directly after `getMinifyCss()`

removed unused imports

commented unused private field named `classpath`

removed trailing whitespace & empty line near end of file