### PR TITLE
Do not allow JarAssetResolver to process non-jar files. 

### DIFF
--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/fs/JarAssetResolver.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/fs/JarAssetResolver.groovy
@@ -24,6 +24,7 @@ import java.util.jar.JarEntry
 import java.util.regex.Pattern
 import java.util.jar.JarFile
 import java.util.zip.ZipEntry
+import java.util.zip.ZipException
 
 
 /**
@@ -42,7 +43,12 @@ class JarAssetResolver extends AbstractAssetResolver<ZipEntry> {
 
 	JarAssetResolver(String name,String jarPath, String prefixPath) {
 		super(name)
-		baseJar = new JarFile(jarPath)
+		try {
+			baseJar = new JarFile(jarPath)
+		} catch (ZipException x) {
+			log.error "ERROR: Jar file is corrupted ${jarPath}"
+			throw x
+		}
 		this.prefixPath = prefixPath
 	}
 

--- a/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetCompile.groovy
+++ b/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetCompile.groovy
@@ -197,7 +197,8 @@ class AssetCompile extends DefaultTask {
     }
     
     void registerJarResolvers(File jarFile) {
-        if (jarFile.exists()) {
+        def isJarFile = jarFile.name.endsWith('.jar') || jarFile.name.endsWith('.zip')
+        if (jarFile.exists() && isJarFile) {
             AssetPipelineConfigHolder.registerResolver(new JarAssetResolver(jarFile.name, jarFile.canonicalPath, 'META-INF/assets'))
             AssetPipelineConfigHolder.registerResolver(new JarAssetResolver(jarFile.name, jarFile.canonicalPath, 'META-INF/static'))
             AssetPipelineConfigHolder.registerResolver(new JarAssetResolver(jarFile.name, jarFile.canonicalPath, 'META-INF/resources'))


### PR DESCRIPTION
I came into a situation where a pom file was in the classpath and I kept getting a ZipException. Because JarAssetResolver kept trying to open the pom file as a Jar file. 

This code fixed it for me.

